### PR TITLE
Fix vendored build with cmake

### DIFF
--- a/build/build.rs
+++ b/build/build.rs
@@ -8,7 +8,7 @@ use std::io::BufReader;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
-const P8_PLATFORM_DIR_ENV: &str = "p8-platform_DIR";
+const P8_PLATFORM_ROOT_ENV: &str = "p8-platform_ROOT";
 const LIBCEC_BUILD: &str = "libcec_build";
 const PLATFORM_BUILD: &str = "platform_build";
 const LIBCEC_SRC: &str = "vendor";
@@ -66,13 +66,13 @@ fn compile_vendored_platform(dst: &Path) {
     println!("cmake platform");
     cmake::Config::new(dst.join(LIBCEC_SRC).join("src").join("platform"))
         .out_dir(&platform_build)
-        .env(P8_PLATFORM_DIR_ENV, &platform_build)
+        .env(P8_PLATFORM_ROOT_ENV, &platform_build)
         .build();
 
     println!("make platform");
     Command::new("make")
         .current_dir(&platform_build)
-        .env(P8_PLATFORM_DIR_ENV, &platform_build)
+        .env(P8_PLATFORM_ROOT_ENV, &platform_build)
         .status()
         .expect("failed to make libcec platform!");
 }
@@ -84,13 +84,13 @@ fn compile_vendored_libcec(dst: &Path) {
     println!("cmake libcec");
     cmake::Config::new(&dst.join(LIBCEC_SRC))
         .out_dir(&libcec_build)
-        .env(P8_PLATFORM_DIR_ENV, &platform_build)
+        .env(P8_PLATFORM_ROOT_ENV, &platform_build)
         .build();
 
     println!("make libcec");
     Command::new("make")
         .current_dir(&libcec_build)
-        .env(P8_PLATFORM_DIR_ENV, &platform_build)
+        .env(P8_PLATFORM_ROOT_ENV, &platform_build)
         .status()
         .expect("failed to make libcec!");
 }


### PR DESCRIPTION
<!-- Please explain the changes you made -->
https://github.com/ssalonen/libcec-sys/pull/14#issuecomment-1191939994 from @ok-nick 

> I ran the CI on my repo and it seems there are a few issues compiling vendored libcec v6. https://github.com/ok-nick/libcec-sys/runs/7457424524?check_suite_focus=true#step:12:547

libcec6 imposes `cmake_minimum_required(VERSION 3.12.0)` which seems to change behaviour how cmake finds packages. 

https://cmake.org/cmake/help/latest/command/find_package.html
https://cmake.org/cmake/help/latest/policy/CMP0074.html#policy:CMP0074


<!-- Please explain the changes you made -->

<!--
Please, make sure:
- you have read the contributing guidelines:
  https://github.com/ssalonen/libcec-sys/blob/master/docs/CONTRIBUTING.md
- you have formatted the code using rustfmt:
  https://github.com/rust-lang/rustfmt
- you have checked that all tests pass, by running `cargo test --all`
- you have updated the changelog (if needed):
  https://github.com/ssalonen/libcec-sys/blob/master/CHANGELOG.md
-->


<!--
Please, make sure:
- you have read the contributing guidelines:
  https://github.com/ssalonen/libcec-sys/blob/master/docs/CONTRIBUTING.md
- you have formatted the code using rustfmt:
  https://github.com/rust-lang/rustfmt
- you have checked that all tests pass, by running `cargo test --all`
- you have updated the changelog (if needed):
  https://github.com/ssalonen/libcec-sys/blob/master/CHANGELOG.md
-->
